### PR TITLE
fix(backport-2.x, datatable): export header correctly sibling rowspan-ed column

### DIFF
--- a/core/src/main/java/net/bis5/excella/primefaces/exporter/DataTableExcellaExporter.java
+++ b/core/src/main/java/net/bis5/excella/primefaces/exporter/DataTableExcellaExporter.java
@@ -699,10 +699,21 @@ public class DataTableExcellaExporter extends DataTableExporter {
                     continue;
                 }
                 foundExportableColumn = true;
+                while (true) {
+                    var currRowIndex = rowIndex;
+                    var currColIndex = colIndex;
+                    boolean overlapped = mergedAreas.stream()
+                        .anyMatch(a -> a.isInRange(currRowIndex, currColIndex));
+                    if (!overlapped) { break; }
+                    colIndex++;
+                }
                 List<String> columnContents = headerContents.computeIfAbsent(colIndex, c -> new ArrayList<>());
                 columnContents.add(getFacetColumnText(context, column, columnType));
                 if (column.getRowspan() > 1) {
                     mergedAreas.add(new CellRangeAddress(rowIndex, rowIndex + column.getRowspan() - 1, colIndex, colIndex));
+
+                    IntStream.range(rowIndex + 1, rowIndex + column.getRowspan())
+                        .forEach(i -> columnContents.add(null));
                 }
                 if (column.getColspan() > 1) {
                     mergedAreas.add(new CellRangeAddress(rowIndex, rowIndex, colIndex, colIndex + column.getColspan() -1));

--- a/core/src/main/java/net/bis5/excella/primefaces/exporter/DataTableExcellaExporter.java
+++ b/core/src/main/java/net/bis5/excella/primefaces/exporter/DataTableExcellaExporter.java
@@ -700,8 +700,8 @@ public class DataTableExcellaExporter extends DataTableExporter {
                 }
                 foundExportableColumn = true;
                 while (true) {
-                    var currRowIndex = rowIndex;
-                    var currColIndex = colIndex;
+                    int currRowIndex = rowIndex;
+                    int currColIndex = colIndex;
                     boolean overlapped = mergedAreas.stream()
                         .anyMatch(a -> a.isInRange(currRowIndex, currColIndex));
                     if (!overlapped) { break; }

--- a/integration-test/src/main/webapp/ui/data/datatable/complexRowspan.xhtml
+++ b/integration-test/src/main/webapp/ui/data/datatable/complexRowspan.xhtml
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://java.sun.com/jsf/html"
+      xmlns:f="http://java.sun.com/jsf/core"
+      xmlns:ui="http://java.sun.com/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:sc="http://primefaces.org/ui/showcase"
+      lang="en">
+
+    <h:head>
+        <f:facet name="first">
+            <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+            <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+            <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>
+            <meta name="apple-mobile-web-app-capable" content="yes"/>
+        </f:facet>
+        <title>PrimeFaces Showcase</title>
+
+        <!-- For Community Themes except 'Luna' and 'Nova' theme -->
+        <h:outputStylesheet name="primeicons/primeicons.css" library="primefaces"/>
+
+        <h:outputScript name="jquery/jquery.js" library="primefaces"/>
+        <h:outputScript name="jquery/jquery-plugins.js" library="primefaces"/>
+        <h:outputScript name="script/nanoscroller.js" library="showcase"/>
+        <h:outputScript name="script/layout.js" library="showcase"/>
+    </h:head>
+
+    <h:body>
+      <h:form id="form">
+          <p:commandLink id="excellaExportNonAjax" ajax="false">
+              <h:outputLabel>ExCella Reports (non-Ajax)</h:outputLabel>
+              <p:dataExporter type="xls" target="tbl" fileName="complex-non-ajax" exporter="#{excellaExporter.dataTableExporter}" />
+          </p:commandLink>
+          <br />
+          <p:commandLink id="excellaExportAjax" ajax="true">
+              <h:outputLabel>ExCella Reports (Ajax)</h:outputLabel>
+              <p:dataExporter type="xls" target="tbl" fileName="complex-ajax" exporter="#{excellaExporter.dataTableExporter}" />
+          </p:commandLink>
+
+          <p:dataTable id="tbl" var="row" value="#{dtBasicView.dataTypes}">
+            <p:columnGroup type="header">
+              <p:row>
+                <p:column rowspan="3"
+                          headerText="rowspan" />
+                <p:column headerText="headerText A-1" />
+                <p:column headerText="headerText A-2" />
+                <p:column rowspan="3"
+                          headerText="rowspan2" />
+              </p:row>
+              <p:row>
+                <p:column headerText="headerText B-1" />
+                <p:column headerText="headerText B-2" />
+              </p:row>
+              <p:row>
+                <p:column headerText="headerText C-1" />
+                <p:column headerText="headerText C-2" />
+              </p:row>
+            </p:columnGroup>
+              <p:column>
+                  <h:outputText value="#{row.stringProperty}" />
+              </p:column>
+              <p:column>
+                  <h:outputText value="#{row.yearMonthProperty}" />
+              </p:column>
+              <p:column>
+                  <h:outputText value="#{row.localDateProperty}" />
+              </p:column>
+              <p:column>
+                  <h:outputText value="#{row.stringProperty}" />
+              </p:column>
+          </p:dataTable>
+      </h:form>
+    </h:body>
+
+</html>
+

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/ComplexRowspanTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/ComplexRowspanTest.java
@@ -1,0 +1,157 @@
+package net.bis5.excella.primefaces.exporter.datatable;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+
+import org.apache.poi.EncryptedDocumentException;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.CommandLink;
+import org.primefaces.showcase.view.data.datatable.BasicView;
+import org.primefaces.showcase.view.data.datatable.BasicView.DataTypeCheck;
+
+import net.bis5.excella.primefaces.exporter.DataTableExcellaExporter.ValueType;
+import net.bis5.excella.primefaces.exporter.TakeScreenShotAfterFailure;
+
+@ExtendWith(TakeScreenShotAfterFailure.class)
+class ComplexRowspanTest extends AbstractPrimePageTest {
+
+    private String getBaseDir() {
+        return System.getProperty("basedir");
+    }
+
+    private <T> void assertCell(String description, Cell cell, CellType expectedType, T expectedValue, Function<Cell, T> actualValueMapper) {
+        assertAll(description,
+            () -> assertEquals(expectedType, cell.getCellType(), "cell type"),
+            () -> assertEquals(expectedValue, actualValueMapper.apply(cell), "cell value")
+        );
+    }
+
+    private <T> void assertCellFormat(String description, Cell cell, ValueType cellValueType) {
+        Workbook workbook = cell.getRow().getSheet().getWorkbook();
+        short expectedDataFormat = cellValueType.getFormat(workbook);
+
+        CellStyle cellStyle = cell.getCellStyle();
+        assertEquals(expectedDataFormat, cellStyle.getDataFormat(), "CellStyle.dataFormat");
+    }
+
+    @Test
+    void exportExcellaAjax(Page page) throws EncryptedDocumentException, IOException {
+        BasicView backingBean = new BasicView();
+        DataTypeCheck record = backingBean.getDataTypes().get(0);
+
+        CommandLink link = page.commandLinkAjax;
+        link.click();
+        PrimeSelenium.wait(1000);
+
+        assertFileContent(record, "complex-ajax.xlsx");
+    }
+
+    @Test
+    void exportExcellaNonAjax(Page page) throws EncryptedDocumentException, IOException {
+        BasicView backingBean = new BasicView();
+        DataTypeCheck record = backingBean.getDataTypes().get(0);
+
+        CommandLink link = page.commandLinkNonAjax;
+        link.getRoot().click();
+
+        assertFileContent(record, "complex-non-ajax.xlsx");
+    }
+
+    private void assertMergedRegion(Sheet sheet, int fromRowIndex, int fromColIndex, int toRowIndex, int toColIndex) {
+        CellRangeAddress expectedRange = new CellRangeAddress(fromRowIndex, toRowIndex, fromColIndex, toColIndex);
+        List<CellRangeAddress> mergedRegions = sheet.getMergedRegions();
+        assertTrue(mergedRegions.contains(expectedRange), () -> "Cell range [" + expectedRange + "] is not merged. merged regions: " + mergedRegions);
+    }
+
+    private void assertFileContent(DataTypeCheck record, String outputFileName) throws EncryptedDocumentException, IOException {
+        try (Workbook workbook = WorkbookFactory.create(new File(getBaseDir()+"/docker-compose/downloads/" + outputFileName), null, true)) {
+            Sheet sheet = workbook.getSheetAt(0);
+            List<String> headerRowAText = List.of("rowspan", "headerText A-1", "headerText A-2", "rowspan2");
+            List<String> headerRowBText = List.of("", "headerText B-1", "headerText B-2", "");
+            List<String> headerRowCText = List.of("", "headerText C-1", "headerText C-2", "");
+
+            Row headerRowA = sheet.getRow(0);
+            Row headerRowB = sheet.getRow(1);
+            Row headerRowC = sheet.getRow(2);
+            Row dataRow = sheet.getRow(3);
+            assertAll(
+                () -> assertAll("headerRowA", () -> {
+                    assertMergedRegion(sheet, 0, 0, 2, 0);
+                    assertMergedRegion(sheet, 0, 3, 2, 3);
+                    for (int i = 0; i < headerRowAText.size(); i++) {
+                        Cell cell = headerRowA.getCell(i);
+                        assertEquals(CellType.STRING, cell.getCellType());
+                        assertEquals(headerRowAText.get(i), cell.getStringCellValue());
+                    }
+                }),
+                () -> assertAll("headerRowB", () -> {
+                    for (int i = 0; i < headerRowBText.size(); i++) {
+                        Cell cell = headerRowB.getCell(i);
+                        if (headerRowBText.get(i).isEmpty()) {
+                            assertTrue(cell == null || cell.getCellType() == CellType.BLANK,
+                                () -> "merged area cell type must be blank. observed: " + cell.getCellType() + ", value: " + cell.getStringCellValue());
+                            continue;
+                        }
+                        assertEquals(CellType.STRING, cell.getCellType());
+                        assertEquals(headerRowBText.get(i), cell.getStringCellValue());
+                    }
+                }),
+                () -> assertAll("headerRowC", () -> {
+                    for (int i = 0; i < headerRowCText.size(); i++) {
+                        Cell cell = headerRowC.getCell(i);
+                        if (headerRowBText.get(i).isEmpty()) {
+                            assertTrue(cell == null || cell.getCellType() == CellType.BLANK,
+                                () -> "merged area cell type must be blank. observed: " + cell.getCellType() + ", value: " + cell.getStringCellValue());
+                            continue;
+                        }
+                        assertEquals(CellType.STRING, cell.getCellType());
+                        assertEquals(headerRowCText.get(i), cell.getStringCellValue());
+                    }
+                }),
+                () -> assertAll("Data row",
+                    () -> assertCell("String cell", dataRow.getCell(0), CellType.STRING, record.getStringProperty(), Cell::getStringCellValue),
+                    () -> assertCell("YearMonth cell", dataRow.getCell(1), CellType.NUMERIC, record.getYearMonthProperty().atDay(1).atStartOfDay(), Cell::getLocalDateTimeCellValue),
+                    () -> assertCellFormat("YearMonth cell data format", dataRow.getCell(1), ValueType.YEAR_MONTH),
+                    () -> assertCell("LocalDate cell", dataRow.getCell(2), CellType.NUMERIC, record.getLocalDateProperty().atStartOfDay(), Cell::getLocalDateTimeCellValue),
+                    () -> assertCellFormat("LocalDate cell data format", dataRow.getCell(2), ValueType.DATE),
+                    () -> assertCell("String cell 2", dataRow.getCell(3), CellType.STRING, record.getStringProperty(), Cell::getStringCellValue)
+                )
+            );
+        }
+    }
+
+    public static class Page extends AbstractPrimePage {
+
+        @FindBy(id = "form:excellaExportNonAjax")
+        CommandLink commandLinkNonAjax;
+
+        @FindBy(id = "form:excellaExportAjax")
+        CommandLink commandLinkAjax;
+
+        @Override
+        public String getLocation() {
+            return "ui/data/datatable/complexRowspan.xhtml";
+        }
+
+    }
+
+}


### PR DESCRIPTION
fix #43