### PR TITLE
 fix: export grouped header/footer columns only once (5.x)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,6 @@ jobs:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
-    - name: Prepare
-      run: chmod 777 docker-compose/downloads
-      working-directory: ./integration-test
     - name: Start browser container
       run: HOST_IP=$(ip a | grep docker0 | grep inet | awk '{print $2;}' | sed 's/\/.*$//') docker compose up -d
       working-directory: ./integration-test

--- a/core/src/main/java/net/bis5/excella/primefaces/exporter/ExCellaExporter.java
+++ b/core/src/main/java/net/bis5/excella/primefaces/exporter/ExCellaExporter.java
@@ -475,6 +475,7 @@ interface ExCellaExporter<T extends UITable<?>> {
                 } else {
                     exportFacetColumns(context, child.getChildren(), columnType, reportSheet, facetColumns);
                 }
+                return;
             } else if (child instanceof UIColumn) {
                 exportFacetColumns(context, columnGroup.getChildren(), columnType, reportSheet, facetColumns);
             } else {

--- a/integration-test/docker-compose.yml
+++ b/integration-test/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     image: selenium/standalone-chrome
     ports:
       - "4444:4444"
-    volumes:
-      - "./docker-compose/downloads:/home/seluser/Downloads"
+      - "7900:7900" # VNC
     extra_hosts:
       - "docker-host:$HOST_IP"
+    environment:
+      - "SE_OPTS=--enable-managed-downloads true"

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/Assertions.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/Assertions.java
@@ -39,4 +39,33 @@ public class Assertions {
     public static void assertBlankCell(String description, Cell cell) {
         assertEquals(CellType.BLANK, cell.getCellType(), "Cell is not blank");
     }
+
+    public static void assertExportArea(Sheet sheet, int expectedFirstRowIndex, int expectedLastRowIndex, int expectedFirstColIndex, int expectedLastColIndex) {
+        assertEquals(expectedFirstRowIndex, sheet.getFirstRowNum(), "first row index is incorrect");
+        assertEquals(expectedLastRowIndex, sheet.getLastRowNum(), "last row index is incorrect");
+
+        int actualFirstColIndex = Integer.MAX_VALUE;
+        int actualLastColIndex = Integer.MIN_VALUE;
+        for (int i = expectedFirstRowIndex; i <= expectedLastRowIndex; i++) {
+            var row = sheet.getRow(i);
+            if (row == null) {
+                continue;
+            }
+            if (row.getFirstCellNum() >= 0) {
+                actualFirstColIndex = Math.min(actualFirstColIndex, row.getFirstCellNum());
+            }
+            if (row.getLastCellNum() >= 0) {
+                actualLastColIndex = Math.max(actualLastColIndex, row.getLastCellNum() - 1);
+            }
+        }
+        if (actualFirstColIndex == Integer.MAX_VALUE) {
+            actualFirstColIndex = -1;
+        }
+        if (actualLastColIndex == Integer.MIN_VALUE) {
+            actualLastColIndex = -1;
+        }
+
+        assertEquals(expectedFirstColIndex, actualFirstColIndex, "first column index is incorrect");
+        assertEquals(expectedLastColIndex, actualLastColIndex, "last column index is incorrect");
+    }
 }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/Download.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/Download.java
@@ -1,0 +1,17 @@
+package net.bis5.excella.primefaces.exporter;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.openqa.selenium.HasDownloads;
+import org.primefaces.selenium.PrimeSelenium;
+
+public class Download {
+
+    public static Path downloadFileToLocal(String fileName) throws IOException {
+        Path localDir = Paths.get(System.getProperty("basedir") ,"target", "downloads");
+        ((HasDownloads)PrimeSelenium.getWebDriver()).downloadFile(fileName, localDir.toAbsolutePath());
+        return localDir.resolve(fileName);
+    }
+}

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/PrimeSeleniumWildflyChromeAdapter.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/PrimeSeleniumWildflyChromeAdapter.java
@@ -1,8 +1,12 @@
 package net.bis5.excella.primefaces.exporter;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Collections;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.logging.Level;
 
@@ -23,19 +27,12 @@ public class PrimeSeleniumWildflyChromeAdapter implements WebDriverAdapter, Depl
         ChromeOptions options = new ChromeOptions();
         options.setPageLoadStrategy(PageLoadStrategy.NORMAL);
 
-        boolean headless = Boolean.valueOf(System.getProperty("webdriver.headless"));
-        if (headless) {
-            // https://www.selenium.dev/blog/2023/headless-is-going-away/
-            options.addArguments("--headless=new");
-        }
-
+        options.setEnableDownloads(true);
         options.addArguments("--disable-dev-shm-usage");
         options.addArguments("--no-sandbox");
         options.addArguments("--remote-debugging-port=9222");
         options.addArguments("--unsafely-treat-insecure-origin-as-secure="+getBaseUrl());
 
-        Map<String, Object> prefs = Collections.singletonMap("download.default_directory", "/home/seluser/Downloads");
-        options.setExperimentalOption("prefs", prefs);
         LoggingPreferences logPrefs = new LoggingPreferences();
         logPrefs.enable(LogType.BROWSER, Level.ALL);
         options.setCapability("goog::loggingPrefs", logPrefs);
@@ -69,7 +66,25 @@ public class PrimeSeleniumWildflyChromeAdapter implements WebDriverAdapter, Depl
 
     @Override
     public void initialize(ConfigProvider configProvider) {
-        // no op
+        createDownloadLocalDir();
     }
 
+    private void createDownloadLocalDir() {
+        Path localDir = Paths.get(System.getProperty("basedir"), "target", "downloads");
+        if (!localDir.toFile().exists()) {
+            localDir.toFile().mkdirs();
+        }
+        try {
+            Files.walk(localDir).filter(Files::isRegularFile)
+                .forEach(file -> {
+                    try {
+                        Files.delete(file);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
 }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/PrimeSeleniumWildflyChromeAdapter.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/PrimeSeleniumWildflyChromeAdapter.java
@@ -7,7 +7,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Map;
 import java.util.logging.Level;
 
 import org.openqa.selenium.PageLoadStrategy;

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/ComplexRowspanTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/ComplexRowspanTest.java
@@ -5,8 +5,8 @@ import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,15 +29,12 @@ import org.primefaces.selenium.component.CommandLink;
 import org.primefaces.showcase.view.data.datatable.BasicView;
 import org.primefaces.showcase.view.data.datatable.BasicView.DataTypeCheck;
 
+import net.bis5.excella.primefaces.exporter.Download;
 import net.bis5.excella.primefaces.exporter.TakeScreenShotAfterFailure;
 import net.bis5.excella.primefaces.exporter.ValueType;
 
 @ExtendWith(TakeScreenShotAfterFailure.class)
 class ComplexRowspanTest extends AbstractPrimePageTest {
-
-    private String getBaseDir() {
-        return System.getProperty("basedir");
-    }
 
     @Test
     void exportExcellaAjax(Page page) throws EncryptedDocumentException, IOException {
@@ -69,7 +66,8 @@ class ComplexRowspanTest extends AbstractPrimePageTest {
     }
 
     private void assertFileContent(DataTypeCheck record, String outputFileName) throws EncryptedDocumentException, IOException {
-        try (Workbook workbook = WorkbookFactory.create(new File(getBaseDir()+"/docker-compose/downloads/" + outputFileName), null, true)) {
+        Path localFile = Download.downloadFileToLocal(outputFileName);
+        try (Workbook workbook = WorkbookFactory.create(localFile.toFile(), null, true)) {
             Sheet sheet = workbook.getSheetAt(0);
             List<String> headerRowAText = List.of("rowspan", "headerText A-1", "headerText A-2", "rowspan2");
             List<String> headerRowBText = List.of("", "headerText B-1", "headerText B-2", "");

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/ComplexRowspanTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/ComplexRowspanTest.java
@@ -1,6 +1,7 @@
 package net.bis5.excella.primefaces.exporter.datatable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -125,7 +126,8 @@ class ComplexRowspanTest extends AbstractPrimePageTest {
                     () -> assertCell("YearMonth cell", dataRow.getCell(1), CellType.NUMERIC, ValueType.YEAR_MONTH, record.getYearMonthProperty().atDay(1).atStartOfDay(), Cell::getLocalDateTimeCellValue),
                     () -> assertCell("LocalDate cell", dataRow.getCell(2), CellType.NUMERIC, ValueType.DATE, record.getLocalDateProperty().atStartOfDay(), Cell::getLocalDateTimeCellValue),
                     () -> assertCell("String cell 2", dataRow.getCell(3), CellType.STRING, ValueType.STRING, record.getStringProperty(), Cell::getStringCellValue)
-                )
+                ),
+                () -> assertExportArea(sheet, 0, 3 + /*template footer*/1, 0, 3)
             );
         }
     }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataBasicTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataBasicTest.java
@@ -1,6 +1,7 @@
 package net.bis5.excella.primefaces.exporter.datatable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -127,7 +128,8 @@ public class DataBasicTest extends AbstractPrimePageTest {
                     assertions.add(() -> assertHeaderCell(index, cell, expectedFooterValue));
                 }
                 assertAll("Footer row", assertions.toArray(Executable[]::new));
-            }
+            },
+            () -> assertExportArea(sheet, 0, 2, 0, 14)
         );
     }
 

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataBasicTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataBasicTest.java
@@ -5,7 +5,6 @@ import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataBasicTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataBasicTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -28,15 +29,12 @@ import org.primefaces.selenium.component.CommandLink;
 import org.primefaces.showcase.view.data.datatable.BasicView;
 import org.primefaces.showcase.view.data.datatable.BasicView.DataTypeCheck;
 
+import net.bis5.excella.primefaces.exporter.Download;
 import net.bis5.excella.primefaces.exporter.TakeScreenShotAfterFailure;
 import net.bis5.excella.primefaces.exporter.ValueType;
 
 @ExtendWith(TakeScreenShotAfterFailure.class)
 public class DataBasicTest extends AbstractPrimePageTest {
-
-    private String getBaseDir() {
-        return System.getProperty("basedir");
-    }
 
     @Test
     void exportExcellaAjax(Page page) throws EncryptedDocumentException, IOException {
@@ -62,7 +60,8 @@ public class DataBasicTest extends AbstractPrimePageTest {
     }
 
     private void assertFileContent(DataTypeCheck record, String outputFileName) throws EncryptedDocumentException, IOException {
-        try (Workbook workbook = WorkbookFactory.create(new File(getBaseDir()+"/docker-compose/downloads/" + outputFileName), null, true)) {
+        Path localFile = Download.downloadFileToLocal(outputFileName);
+        try (Workbook workbook = WorkbookFactory.create(localFile.toFile(), null, true)) {
             assertFileContent(record, workbook);
         }
     }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataBeforeWriteResponseListenerTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataBeforeWriteResponseListenerTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.security.GeneralSecurityException;
 
@@ -23,14 +23,11 @@ import org.primefaces.selenium.component.CommandLink;
 import org.primefaces.showcase.view.data.datatable.BasicView;
 import org.primefaces.showcase.view.data.datatable.BasicView.DataTypeCheck;
 
+import net.bis5.excella.primefaces.exporter.Download;
 import net.bis5.excella.primefaces.exporter.TakeScreenShotAfterFailure;
 
 @ExtendWith(TakeScreenShotAfterFailure.class)
 class DataBeforeWriteResponseListenerTest extends AbstractPrimePageTest {
-
-    private String getBaseDir() {
-        return System.getProperty("basedir");
-    }
 
     @Test
     void exportExcellaAjax(Page page) throws IOException, GeneralSecurityException {
@@ -56,7 +53,8 @@ class DataBeforeWriteResponseListenerTest extends AbstractPrimePageTest {
     }
 
     private void assertFileContent(DataTypeCheck data, String outputFileName) throws IOException, GeneralSecurityException {
-        try (InputStream is = Files.newInputStream(Paths.get(getBaseDir() + "/docker-compose/downloads/" + outputFileName), StandardOpenOption.READ);
+        Path localFile = Download.downloadFileToLocal(outputFileName);
+        try (InputStream is = Files.newInputStream(localFile, StandardOpenOption.READ);
                 POIFSFileSystem fs = new POIFSFileSystem(is)) {
             EncryptionInfo info = new EncryptionInfo(fs);
             Decryptor dc = Decryptor.getInstance(info);

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataExportableColumnTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataExportableColumnTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -29,15 +30,12 @@ import org.primefaces.selenium.component.CommandLink;
 import org.primefaces.showcase.view.data.datatable.BasicView;
 import org.primefaces.showcase.view.data.datatable.BasicView.DataTypeCheck;
 
+import net.bis5.excella.primefaces.exporter.Download;
 import net.bis5.excella.primefaces.exporter.TakeScreenShotAfterFailure;
 import net.bis5.excella.primefaces.exporter.ValueType;
 
 @ExtendWith(TakeScreenShotAfterFailure.class)
 class DataExportableColumnTest extends AbstractPrimePageTest {
-
-    private String getBaseDir() {
-        return System.getProperty("basedir");
-    }
 
     @Test
     void exportExcellaAjax(Page page) throws EncryptedDocumentException, IOException {
@@ -86,7 +84,8 @@ class DataExportableColumnTest extends AbstractPrimePageTest {
     }
 
     private void assertFileContent(DataTypeCheck record, String outputFileName, boolean visibleOnly) throws EncryptedDocumentException, IOException {
-        try (Workbook workbook = WorkbookFactory.create(new File(getBaseDir()+"/docker-compose/downloads/" + outputFileName), null, true)) {
+        Path localFile = Download.downloadFileToLocal(outputFileName);
+        try (Workbook workbook = WorkbookFactory.create(localFile.toFile(), null, true)) {
             Sheet sheet = workbook.getSheetAt(0);
             List<String> headers = visibleOnly ? Arrays.asList("String", "j.u.Date (date)") : Arrays.asList("String", "invisible", "j.u.Date (date)");
 

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataExportableColumnTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataExportableColumnTest.java
@@ -5,7 +5,6 @@ import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataExportableColumnTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataExportableColumnTest.java
@@ -1,6 +1,7 @@
 package net.bis5.excella.primefaces.exporter.datatable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -123,7 +124,8 @@ class DataExportableColumnTest extends AbstractPrimePageTest {
                         assertions.add(() -> assertHeaderCell(index, cell, expectedFooterValue));
                     }
                     assertAll("Footer row", assertions.toArray(Executable[]::new));
-                }
+                },
+                () -> assertExportArea(sheet, 0, 2, 0, headers.size() - 1)
             );
         }
     }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataTableNoDataTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataTableNoDataTest.java
@@ -1,37 +1,32 @@
 package net.bis5.excella.primefaces.exporter.datatable;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 
 import org.apache.poi.EncryptedDocumentException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.support.FindBy;
 import org.primefaces.selenium.AbstractPrimePage;
 import org.primefaces.selenium.AbstractPrimePageTest;
 import org.primefaces.selenium.PrimeSelenium;
 import org.primefaces.selenium.component.CommandLink;
 
+import net.bis5.excella.primefaces.exporter.Download;
 import net.bis5.excella.primefaces.exporter.TakeScreenShotAfterFailure;
 
 @ExtendWith(TakeScreenShotAfterFailure.class)
 class DataTableNoDataTest extends AbstractPrimePageTest {
 
-    private String getBaseDir() {
-        return System.getProperty("basedir");
-    }
-
     private void assertNoFile(String outputFileName) {
-        var path = Paths.get(getBaseDir(), "/docker-compose/downloads/" + outputFileName);
-        assertFalse(path.toFile().exists(), () -> "File " + path + " was unexpectedly created");
+        assertThrows(WebDriverException.class, () -> Download.downloadFileToLocal(outputFileName));
     }
 
     private void assertFileExists(String outputFileName) {
-        var path = Paths.get(getBaseDir(), "/docker-compose/downloads/" + outputFileName);
-        assertTrue(path.toFile().exists(), () -> "File " + path + " is not found");
+        assertDoesNotThrow(() -> Download.downloadFileToLocal(outputFileName));
     }
 
     @Test

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/MergedHeaderFooterTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/MergedHeaderFooterTest.java
@@ -7,7 +7,6 @@ import static net.bis5.excella.primefaces.exporter.Assertions.assertMergedRegion
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/MergedHeaderFooterTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/MergedHeaderFooterTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -30,15 +31,12 @@ import org.primefaces.selenium.component.CommandLink;
 import org.primefaces.showcase.view.data.datatable.BasicView.DataTypeCheck;
 import org.primefaces.showcase.view.data.datatable.MergedHeaderFooterView;
 
+import net.bis5.excella.primefaces.exporter.Download;
 import net.bis5.excella.primefaces.exporter.TakeScreenShotAfterFailure;
 import net.bis5.excella.primefaces.exporter.ValueType;
 
 @ExtendWith(TakeScreenShotAfterFailure.class)
 class MergedHeaderFooterTest extends AbstractPrimePageTest {
-
-    private String getBaseDir() {
-        return System.getProperty("basedir");
-    }
 
     @Test
     void exportExcellaAjax(Page page) throws EncryptedDocumentException, IOException {
@@ -66,7 +64,8 @@ class MergedHeaderFooterTest extends AbstractPrimePageTest {
     private static final int ROW_OFFSET = 2;
     private static final int COL_OFFSET = 1;
     private void assertFileContent(DataTypeCheck record, String outputFileName) throws EncryptedDocumentException, IOException {
-        try (Workbook workbook = WorkbookFactory.create(new File(getBaseDir()+"/docker-compose/downloads/" + outputFileName), null, true)) {
+        Path localFile = Download.downloadFileToLocal(outputFileName);
+        try (Workbook workbook = WorkbookFactory.create(localFile.toFile(), null, true)) {
             Sheet sheet = workbook.getSheetAt(0);
             List<String> detailHeaders = Arrays.asList("headerText B-1", "headerText B-2");
 
@@ -138,7 +137,8 @@ class MergedHeaderFooterTest extends AbstractPrimePageTest {
     }
 
     private void assertFileContentSingleRow(DataTypeCheck record, String outputFileName) throws EncryptedDocumentException, IOException {
-        try (Workbook workbook = WorkbookFactory.create(new File(getBaseDir()+"/docker-compose/downloads/" + outputFileName), null, true)) {
+        Path localFile = Download.downloadFileToLocal(outputFileName);
+        try (Workbook workbook = WorkbookFactory.create(localFile.toFile(), null, true)) {
             Sheet sheet = workbook.getSheetAt(0);
 
             Row groupedHeaderRow = sheet.getRow(ROW_OFFSET + 0);

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/MergedHeaderFooterTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/MergedHeaderFooterTest.java
@@ -1,6 +1,7 @@
 package net.bis5.excella.primefaces.exporter.datatable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertMergedRegion;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -108,7 +109,8 @@ class MergedHeaderFooterTest extends AbstractPrimePageTest {
                 () -> assertAll("EOS row",
                     () -> assertMergedRegion(sheet, ROW_OFFSET + 4, COL_OFFSET + 0, ROW_OFFSET + 4, COL_OFFSET + 2),
                     () -> assertEquals("EOS", eosRow.getCell(COL_OFFSET + 0).getStringCellValue())
-                )
+                ),
+                () -> assertExportArea(sheet, 0, 6, 0, 5)
             );
         }
     }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeBasicTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeBasicTest.java
@@ -1,6 +1,7 @@
 package net.bis5.excella.primefaces.exporter.treetable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -200,7 +201,8 @@ class TreeBasicTest extends AbstractPrimePageTest {
                     assertions.add(() -> assertHeaderCell(index, cell, expectedHeaderValue));
                 }
                 assertAll("Footer row", assertions.toArray(Executable[]::new));
-            }
+            },
+            () -> assertExportArea(sheet, 0, 5, 0, headers.size() - 1)
         );
     }
 

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeBasicTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeBasicTest.java
@@ -5,8 +5,8 @@ import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -30,15 +30,12 @@ import org.primefaces.selenium.component.CommandLink;
 import org.primefaces.showcase.view.data.treetable.BasicView;
 import org.primefaces.showcase.view.data.treetable.BasicView.DataTypeCheck;
 
+import net.bis5.excella.primefaces.exporter.Download;
 import net.bis5.excella.primefaces.exporter.TakeScreenShotAfterFailure;
 import net.bis5.excella.primefaces.exporter.ValueType;
 
 @ExtendWith(TakeScreenShotAfterFailure.class)
 class TreeBasicTest extends AbstractPrimePageTest {
-
-    private String getBaseDir() {
-        return System.getProperty("basedir");
-    }
 
     @Test
     void exportExcellaAjax(Page page) throws EncryptedDocumentException, IOException {
@@ -78,7 +75,8 @@ class TreeBasicTest extends AbstractPrimePageTest {
     }
 
     private void assertFileContent(DataTypeCheck parentRecord1, DataTypeCheck childRecord1, DataTypeCheck parentRecord2, DataTypeCheck childRecord2, String fileName) throws EncryptedDocumentException, IOException {
-        try (Workbook workbook = WorkbookFactory.create(new File(getBaseDir()+"/docker-compose/downloads/" + fileName), null, true)) {
+        Path localFile = Download.downloadFileToLocal(fileName);
+        try (Workbook workbook = WorkbookFactory.create(localFile.toFile(), null, true)) {
             assertFileContent(parentRecord1, childRecord1, parentRecord2, childRecord2, workbook);
         }
     }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeBeforeWriteResponseTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeBeforeWriteResponseTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.security.GeneralSecurityException;
 
@@ -24,14 +24,11 @@ import org.primefaces.selenium.component.CommandLink;
 import org.primefaces.showcase.view.data.treetable.BasicView;
 import org.primefaces.showcase.view.data.treetable.BasicView.DataTypeCheck;
 
+import net.bis5.excella.primefaces.exporter.Download;
 import net.bis5.excella.primefaces.exporter.TakeScreenShotAfterFailure;
 
 @ExtendWith(TakeScreenShotAfterFailure.class)
 class TreeBeforeWriteResponseTest extends AbstractPrimePageTest {
-
-    private String getBaseDir() {
-        return System.getProperty("basedir");
-    }
 
     @Test
     void exportExcellaAjax(Page page) throws IOException, GeneralSecurityException {
@@ -71,7 +68,8 @@ class TreeBeforeWriteResponseTest extends AbstractPrimePageTest {
     }
 
     private void assertFileContent(DataTypeCheck parentRecord1, DataTypeCheck childRecord1, DataTypeCheck parentRecord2, DataTypeCheck childRecord2, String outputFileName) throws IOException, GeneralSecurityException {
-        try (InputStream is = Files.newInputStream(Paths.get(getBaseDir() + "/docker-compose/downloads/" + outputFileName), StandardOpenOption.READ);
+        Path localFile = Download.downloadFileToLocal(outputFileName);
+        try (InputStream is = Files.newInputStream(localFile, StandardOpenOption.READ);
                 POIFSFileSystem fs = new POIFSFileSystem(is)) {
             EncryptionInfo info = new EncryptionInfo(fs);
             Decryptor dc = Decryptor.getInstance(info);

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeExportableColumnTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeExportableColumnTest.java
@@ -5,8 +5,8 @@ import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -31,15 +31,12 @@ import org.primefaces.selenium.component.CommandLink;
 import org.primefaces.showcase.view.data.treetable.BasicView;
 import org.primefaces.showcase.view.data.treetable.BasicView.DataTypeCheck;
 
+import net.bis5.excella.primefaces.exporter.Download;
 import net.bis5.excella.primefaces.exporter.TakeScreenShotAfterFailure;
 import net.bis5.excella.primefaces.exporter.ValueType;
 
 @ExtendWith(TakeScreenShotAfterFailure.class)
 class TreeExportableColumnTest extends AbstractPrimePageTest {
-
-    private String getBaseDir() {
-        return System.getProperty("basedir");
-    }
 
     @Test
     void exportExcellaAjax(Page page) throws EncryptedDocumentException, IOException {
@@ -108,7 +105,8 @@ class TreeExportableColumnTest extends AbstractPrimePageTest {
     }
 
     private void assertFileContent(DataTypeCheck parentRecord, DataTypeCheck childRecord, String outputFileName, boolean visibleOnly) throws EncryptedDocumentException, IOException {
-        try (Workbook workbook = WorkbookFactory.create(new File(getBaseDir()+"/docker-compose/downloads/" + outputFileName), null, true)) {
+        Path localFile = Download.downloadFileToLocal(outputFileName);
+        try (Workbook workbook = WorkbookFactory.create(localFile.toFile(), null, true)) {
             Sheet sheet = workbook.getSheetAt(0);
             List<String> headers = visibleOnly ? Arrays.asList("String", "j.u.Date (date)") : Arrays.asList("String", "invisible", "j.u.Date (date)");
 

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeExportableColumnTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeExportableColumnTest.java
@@ -1,6 +1,7 @@
 package net.bis5.excella.primefaces.exporter.treetable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -157,7 +158,8 @@ class TreeExportableColumnTest extends AbstractPrimePageTest {
                         assertions.add(() -> assertHeaderCell(index, cell, expectedFooterValue));
                     }
                     assertAll("Footer row", assertions.toArray(Executable[]::new));
-                }
+                },
+                () -> assertExportArea(sheet, 0, 3, 0, headers.size() - 1)
             );
         }
     }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeMergedHeaderFooterTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeMergedHeaderFooterTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -31,15 +32,12 @@ import org.primefaces.selenium.component.CommandLink;
 import org.primefaces.showcase.view.data.treetable.BasicView.DataTypeCheck;
 import org.primefaces.showcase.view.data.treetable.MergedHeaderFooterView;
 
+import net.bis5.excella.primefaces.exporter.Download;
 import net.bis5.excella.primefaces.exporter.TakeScreenShotAfterFailure;
 import net.bis5.excella.primefaces.exporter.ValueType;
 
 @ExtendWith(TakeScreenShotAfterFailure.class)
 class TreeMergedHeaderFooterTest extends AbstractPrimePageTest {
-
-    private String getBaseDir() {
-        return System.getProperty("basedir");
-    }
 
     @Test
     void exportExcellaAjax(Page page) throws EncryptedDocumentException, IOException {
@@ -79,7 +77,8 @@ class TreeMergedHeaderFooterTest extends AbstractPrimePageTest {
     private static final int ROW_OFFSET = 2;
     private static final int COL_OFFSET = 1;
     private void assertFileContent(DataTypeCheck parentRecord1, DataTypeCheck childRecord1, DataTypeCheck parentRecord2, DataTypeCheck childRecord2, String outputFileName) throws EncryptedDocumentException, IOException {
-        try (Workbook workbook = WorkbookFactory.create(new File(getBaseDir()+"/docker-compose/downloads/" + outputFileName), null, true)) {
+        Path localFile = Download.downloadFileToLocal(outputFileName);
+        try (Workbook workbook = WorkbookFactory.create(localFile.toFile(), null, true)) {
             Sheet sheet = workbook.getSheetAt(0);
             List<String> detailHeaders = Arrays.asList("headerText B-1", "headerText B-2");
 
@@ -185,7 +184,8 @@ class TreeMergedHeaderFooterTest extends AbstractPrimePageTest {
     }
 
     private void assertFileContentSingleRow(DataTypeCheck parentRecord1, DataTypeCheck childRecord1, DataTypeCheck parentRecord2, DataTypeCheck childRecord2, String outputFileName) throws EncryptedDocumentException, IOException {
-        try (Workbook workbook = WorkbookFactory.create(new File(getBaseDir()+"/docker-compose/downloads/" + outputFileName), null, true)) {
+        Path localFile = Download.downloadFileToLocal(outputFileName);
+        try (Workbook workbook = WorkbookFactory.create(localFile.toFile(), null, true)) {
             Sheet sheet = workbook.getSheetAt(0);
 
             Row groupedHeaderRow = sheet.getRow(ROW_OFFSET + 0);

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeMergedHeaderFooterTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeMergedHeaderFooterTest.java
@@ -7,7 +7,6 @@ import static net.bis5.excella.primefaces.exporter.Assertions.assertMergedRegion
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeMergedHeaderFooterTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeMergedHeaderFooterTest.java
@@ -1,6 +1,7 @@
 package net.bis5.excella.primefaces.exporter.treetable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertMergedRegion;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -143,7 +144,8 @@ class TreeMergedHeaderFooterTest extends AbstractPrimePageTest {
                 () -> assertAll("EOS row",
                     () -> assertMergedRegion(sheet, ROW_OFFSET + 7, COL_OFFSET + 0, ROW_OFFSET + 7, COL_OFFSET + 2),
                     () -> assertEquals("EOS", eosRow.getCell(COL_OFFSET + 0).getStringCellValue())
-                )
+                ),
+                () -> assertExportArea(sheet, 0, 9, 0, 5)
             );
         }
     }
@@ -231,7 +233,8 @@ class TreeMergedHeaderFooterTest extends AbstractPrimePageTest {
                 () -> assertAll("Grouped Footer row",
                     () -> assertMergedRegion(sheet, ROW_OFFSET + 5, COL_OFFSET + 0, ROW_OFFSET + 5, COL_OFFSET + 2),
                     () -> assertEquals("colspan3", groupedFooterRow.getCell(COL_OFFSET + 0).getStringCellValue())
-                )
+                ),
+                () -> assertExportArea(sheet, 0, 7, 0, 5)
             );
         }
     }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeNodeVarTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeNodeVarTest.java
@@ -7,7 +7,6 @@ import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeNodeVarTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeNodeVarTest.java
@@ -2,6 +2,7 @@ package net.bis5.excella.primefaces.exporter.treetable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertBlankCell;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -159,7 +160,8 @@ class TreeNodeVarTest extends AbstractPrimePageTest {
                     () -> assertCell("YearMonth cell", childNodeRow4.getCell(1), CellType.NUMERIC, ValueType.YEAR_MONTH, childRecord2.getYearMonthProperty().atDay(1).atStartOfDay(), Cell::getLocalDateTimeCellValue),
                     () -> assertBlankCell("Date cell", childNodeRow4.getCell(2)),
                     () -> assertCell("Date time cell", childNodeRow4.getCell(3), CellType.NUMERIC, ValueType.DATE_TIME, childRecord2.getDateTimeProperty(), Cell::getDateCellValue)
-                )
+                ),
+                () -> assertExportArea(sheet, 0, 4 + /*template footer*/1, 0, headers.size() - 1)
             );
         }
     }
@@ -197,7 +199,8 @@ class TreeNodeVarTest extends AbstractPrimePageTest {
                     () -> assertCell("YearMonth cell", childNodeRow2.getCell(1), CellType.NUMERIC, ValueType.YEAR_MONTH, childRecord.getYearMonthProperty().atDay(1).atStartOfDay(), Cell::getLocalDateTimeCellValue),
                     () -> assertBlankCell("Date cell", childNodeRow2.getCell(2)),
                     () -> assertCell("Date time cell", childNodeRow2.getCell(3), CellType.NUMERIC, ValueType.DATE_TIME, childRecord.getDateTimeProperty(), Cell::getDateCellValue)
-                )
+                ),
+                () -> assertExportArea(sheet, 0, 2 + /*template footer*/1, 0, headers.size() - 1)
             );
         }
     }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeNodeVarTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeNodeVarTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -32,15 +33,12 @@ import org.primefaces.selenium.component.CommandLink;
 import org.primefaces.showcase.view.data.treetable.BasicView;
 import org.primefaces.showcase.view.data.treetable.BasicView.DataTypeCheck;
 
+import net.bis5.excella.primefaces.exporter.Download;
 import net.bis5.excella.primefaces.exporter.TakeScreenShotAfterFailure;
 import net.bis5.excella.primefaces.exporter.ValueType;
 
 @ExtendWith(TakeScreenShotAfterFailure.class)
 class TreeNodeVarTest extends AbstractPrimePageTest {
-
-    private String getBaseDir() {
-        return System.getProperty("basedir");
-    }
 
     @Test
     void exportExcellaAjax(Page page) throws EncryptedDocumentException, IOException {
@@ -115,7 +113,8 @@ class TreeNodeVarTest extends AbstractPrimePageTest {
     }
 
     private void assertFileContent(DataTypeCheck parentRecord1, DataTypeCheck childRecord1, DataTypeCheck parentRecord2, DataTypeCheck childRecord2, String fileName) throws EncryptedDocumentException, IOException {
-        try (Workbook workbook = WorkbookFactory.create(new File(getBaseDir()+"/docker-compose/downloads/" + fileName), null, true)) {
+        Path localFile = Download.downloadFileToLocal(fileName);
+        try (Workbook workbook = WorkbookFactory.create(localFile.toFile(), null, true)) {
             Sheet sheet = workbook.getSheetAt(0);
             List<String> headers = Arrays.asList("String", "YearMonth", "j.u.Date (date)", "j.u.Date (datetime)");
 
@@ -166,7 +165,8 @@ class TreeNodeVarTest extends AbstractPrimePageTest {
     }
 
     private void assertFileContent(DataTypeCheck parentRecord, DataTypeCheck childRecord, String fileName) throws EncryptedDocumentException, IOException {
-        try (Workbook workbook = WorkbookFactory.create(new File(getBaseDir()+"/docker-compose/downloads/" + fileName), null, true)) {
+        Path localFile = Download.downloadFileToLocal(fileName);
+        try (Workbook workbook = WorkbookFactory.create(localFile.toFile(), null, true)) {
             Sheet sheet = workbook.getSheetAt(0);
             List<String> headers = Arrays.asList("String", "YearMonth", "j.u.Date (date)", "j.u.Date (datetime)");
 

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeTableNoDataTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeTableNoDataTest.java
@@ -1,37 +1,32 @@
 package net.bis5.excella.primefaces.exporter.treetable;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 
 import org.apache.poi.EncryptedDocumentException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.support.FindBy;
 import org.primefaces.selenium.AbstractPrimePage;
 import org.primefaces.selenium.AbstractPrimePageTest;
 import org.primefaces.selenium.PrimeSelenium;
 import org.primefaces.selenium.component.CommandLink;
 
+import net.bis5.excella.primefaces.exporter.Download;
 import net.bis5.excella.primefaces.exporter.TakeScreenShotAfterFailure;
 
 @ExtendWith(TakeScreenShotAfterFailure.class)
 class TreeTableNoDataTest extends AbstractPrimePageTest {
 
-    private String getBaseDir() {
-        return System.getProperty("basedir");
-    }
-
     private void assertNoFile(String outputFileName) {
-        var path = Paths.get(getBaseDir(), "/docker-compose/downloads/" + outputFileName);
-        assertFalse(path.toFile().exists(), () -> "File " + path + " was unexpectedly created");
+        assertThrows(WebDriverException.class, () -> Download.downloadFileToLocal(outputFileName));
     }
 
     private void assertFileExists(String outputFileName) {
-        var path = Paths.get(getBaseDir(), "/docker-compose/downloads/" + outputFileName);
-        assertTrue(path.toFile().exists(), () -> "File " + path + " is not found");
+        assertDoesNotThrow(() -> Download.downloadFileToLocal(outputFileName));
     }
 
     @Test


### PR DESCRIPTION
fixes #103 for 5.x