### PR TITLE
 fix: export grouped header/footer columns only once (4.x-jakarta) 

### DIFF
--- a/core/src/main/java/net/bis5/excella/primefaces/exporter/ExCellaExporter.java
+++ b/core/src/main/java/net/bis5/excella/primefaces/exporter/ExCellaExporter.java
@@ -493,6 +493,7 @@ interface ExCellaExporter<T extends UITable<?>> {
                 } else {
                     exportFacetColumns(context, child.getChildren(), columnType, reportSheet, facetColumns);
                 }
+                return;
             } else if (child instanceof UIColumn) {
                 exportFacetColumns(context, columnGroup.getChildren(), columnType, reportSheet, facetColumns);
             } else {

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/Assertions.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/Assertions.java
@@ -39,4 +39,33 @@ public class Assertions {
     public static void assertBlankCell(String description, Cell cell) {
         assertEquals(CellType.BLANK, cell.getCellType(), "Cell is not blank");
     }
+
+    public static void assertExportArea(Sheet sheet, int expectedFirstRowIndex, int expectedLastRowIndex, int expectedFirstColIndex, int expectedLastColIndex) {
+        assertEquals(expectedFirstRowIndex, sheet.getFirstRowNum(), "first row index is incorrect");
+        assertEquals(expectedLastRowIndex, sheet.getLastRowNum(), "last row index is incorrect");
+
+        int actualFirstColIndex = Integer.MAX_VALUE;
+        int actualLastColIndex = Integer.MIN_VALUE;
+        for (int i = expectedFirstRowIndex; i <= expectedLastRowIndex; i++) {
+            var row = sheet.getRow(i);
+            if (row == null) {
+                continue;
+            }
+            if (row.getFirstCellNum() >= 0) {
+                actualFirstColIndex = Math.min(actualFirstColIndex, row.getFirstCellNum());
+            }
+            if (row.getLastCellNum() >= 0) {
+                actualLastColIndex = Math.max(actualLastColIndex, row.getLastCellNum() - 1);
+            }
+        }
+        if (actualFirstColIndex == Integer.MAX_VALUE) {
+            actualFirstColIndex = -1;
+        }
+        if (actualLastColIndex == Integer.MIN_VALUE) {
+            actualLastColIndex = -1;
+        }
+
+        assertEquals(expectedFirstColIndex, actualFirstColIndex, "first column index is incorrect");
+        assertEquals(expectedLastColIndex, actualLastColIndex, "last column index is incorrect");
+    }
 }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/PrimeSeleniumWildflyChromeAdapter.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/PrimeSeleniumWildflyChromeAdapter.java
@@ -7,7 +7,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Map;
 import java.util.logging.Level;
 
 import org.openqa.selenium.PageLoadStrategy;

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/ComplexRowspanTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/ComplexRowspanTest.java
@@ -1,6 +1,7 @@
 package net.bis5.excella.primefaces.exporter.datatable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -125,7 +126,8 @@ class ComplexRowspanTest extends AbstractPrimePageTest {
                     () -> assertCell("YearMonth cell", dataRow.getCell(1), CellType.NUMERIC, ValueType.YEAR_MONTH, record.getYearMonthProperty().atDay(1).atStartOfDay(), Cell::getLocalDateTimeCellValue),
                     () -> assertCell("LocalDate cell", dataRow.getCell(2), CellType.NUMERIC, ValueType.DATE, record.getLocalDateProperty().atStartOfDay(), Cell::getLocalDateTimeCellValue),
                     () -> assertCell("String cell 2", dataRow.getCell(3), CellType.STRING, ValueType.STRING, record.getStringProperty(), Cell::getStringCellValue)
-                )
+                ),
+                () -> assertExportArea(sheet, 0, 3 + /*template footer*/1, 0, 3)
             );
         }
     }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataBasicTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataBasicTest.java
@@ -1,6 +1,7 @@
 package net.bis5.excella.primefaces.exporter.datatable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -127,7 +128,8 @@ public class DataBasicTest extends AbstractPrimePageTest {
                     assertions.add(() -> assertHeaderCell(index, cell, expectedFooterValue));
                 }
                 assertAll("Footer row", assertions.toArray(Executable[]::new));
-            }
+            },
+            () -> assertExportArea(sheet, 0, 2, 0, 14)
         );
     }
 

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataBasicTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataBasicTest.java
@@ -5,7 +5,6 @@ import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataExportableColumnTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataExportableColumnTest.java
@@ -5,7 +5,6 @@ import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataExportableColumnTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/DataExportableColumnTest.java
@@ -1,6 +1,7 @@
 package net.bis5.excella.primefaces.exporter.datatable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -123,7 +124,8 @@ class DataExportableColumnTest extends AbstractPrimePageTest {
                         assertions.add(() -> assertHeaderCell(index, cell, expectedFooterValue));
                     }
                     assertAll("Footer row", assertions.toArray(Executable[]::new));
-                }
+                },
+                () -> assertExportArea(sheet, 0, 2, 0, headers.size() - 1)
             );
         }
     }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/MergedHeaderFooterTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/MergedHeaderFooterTest.java
@@ -7,7 +7,6 @@ import static net.bis5.excella.primefaces.exporter.Assertions.assertMergedRegion
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/MergedHeaderFooterTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/datatable/MergedHeaderFooterTest.java
@@ -1,6 +1,7 @@
 package net.bis5.excella.primefaces.exporter.datatable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertMergedRegion;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -108,7 +109,8 @@ class MergedHeaderFooterTest extends AbstractPrimePageTest {
                 () -> assertAll("EOS row",
                     () -> assertMergedRegion(sheet, ROW_OFFSET + 4, COL_OFFSET + 0, ROW_OFFSET + 4, COL_OFFSET + 2),
                     () -> assertEquals("EOS", eosRow.getCell(COL_OFFSET + 0).getStringCellValue())
-                )
+                ),
+                () -> assertExportArea(sheet, 0, 6, 0, 5)
             );
         }
     }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeBasicTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeBasicTest.java
@@ -1,6 +1,7 @@
 package net.bis5.excella.primefaces.exporter.treetable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -200,7 +201,8 @@ class TreeBasicTest extends AbstractPrimePageTest {
                     assertions.add(() -> assertHeaderCell(index, cell, expectedHeaderValue));
                 }
                 assertAll("Footer row", assertions.toArray(Executable[]::new));
-            }
+            },
+            () -> assertExportArea(sheet, 0, 5, 0, headers.size() - 1)
         );
     }
 

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeBeforeWriteResponseTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeBeforeWriteResponseTest.java
@@ -30,10 +30,6 @@ import net.bis5.excella.primefaces.exporter.TakeScreenShotAfterFailure;
 @ExtendWith(TakeScreenShotAfterFailure.class)
 class TreeBeforeWriteResponseTest extends AbstractPrimePageTest {
 
-    private String getBaseDir() {
-        return System.getProperty("basedir");
-    }
-
     @Test
     void exportExcellaAjax(Page page) throws IOException, GeneralSecurityException {
         BasicView backingBean = new BasicView();

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeExportableColumnTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeExportableColumnTest.java
@@ -1,6 +1,7 @@
 package net.bis5.excella.primefaces.exporter.treetable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -157,7 +158,8 @@ class TreeExportableColumnTest extends AbstractPrimePageTest {
                         assertions.add(() -> assertHeaderCell(index, cell, expectedFooterValue));
                     }
                     assertAll("Footer row", assertions.toArray(Executable[]::new));
-                }
+                },
+                () -> assertExportArea(sheet, 0, 3, 0, headers.size() - 1)
             );
         }
     }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeMergedHeaderFooterTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeMergedHeaderFooterTest.java
@@ -7,7 +7,6 @@ import static net.bis5.excella.primefaces.exporter.Assertions.assertMergedRegion
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeMergedHeaderFooterTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeMergedHeaderFooterTest.java
@@ -1,6 +1,7 @@
 package net.bis5.excella.primefaces.exporter.treetable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertMergedRegion;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -143,7 +144,8 @@ class TreeMergedHeaderFooterTest extends AbstractPrimePageTest {
                 () -> assertAll("EOS row",
                     () -> assertMergedRegion(sheet, ROW_OFFSET + 7, COL_OFFSET + 0, ROW_OFFSET + 7, COL_OFFSET + 2),
                     () -> assertEquals("EOS", eosRow.getCell(COL_OFFSET + 0).getStringCellValue())
-                )
+                ),
+                () -> assertExportArea(sheet, 0, 9, 0, 5)
             );
         }
     }
@@ -231,7 +233,8 @@ class TreeMergedHeaderFooterTest extends AbstractPrimePageTest {
                 () -> assertAll("Grouped Footer row",
                     () -> assertMergedRegion(sheet, ROW_OFFSET + 5, COL_OFFSET + 0, ROW_OFFSET + 5, COL_OFFSET + 2),
                     () -> assertEquals("colspan3", groupedFooterRow.getCell(COL_OFFSET + 0).getStringCellValue())
-                )
+                ),
+                () -> assertExportArea(sheet, 0, 7, 0, 5)
             );
         }
     }

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeNodeVarTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeNodeVarTest.java
@@ -7,7 +7,6 @@ import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeNodeVarTest.java
+++ b/integration-test/src/test/java/net/bis5/excella/primefaces/exporter/treetable/TreeNodeVarTest.java
@@ -2,6 +2,7 @@ package net.bis5.excella.primefaces.exporter.treetable;
 
 import static net.bis5.excella.primefaces.exporter.Assertions.assertBlankCell;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertCell;
+import static net.bis5.excella.primefaces.exporter.Assertions.assertExportArea;
 import static net.bis5.excella.primefaces.exporter.Assertions.assertHeaderCell;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -159,7 +160,8 @@ class TreeNodeVarTest extends AbstractPrimePageTest {
                     () -> assertCell("YearMonth cell", childNodeRow4.getCell(1), CellType.NUMERIC, ValueType.YEAR_MONTH, childRecord2.getYearMonthProperty().atDay(1).atStartOfDay(), Cell::getLocalDateTimeCellValue),
                     () -> assertBlankCell("Date cell", childNodeRow4.getCell(2)),
                     () -> assertCell("Date time cell", childNodeRow4.getCell(3), CellType.NUMERIC, ValueType.DATE_TIME, childRecord2.getDateTimeProperty(), Cell::getDateCellValue)
-                )
+                ),
+                () -> assertExportArea(sheet, 0, 4 + /*template footer*/1, 0, headers.size() - 1)
             );
         }
     }
@@ -197,7 +199,8 @@ class TreeNodeVarTest extends AbstractPrimePageTest {
                     () -> assertCell("YearMonth cell", childNodeRow2.getCell(1), CellType.NUMERIC, ValueType.YEAR_MONTH, childRecord.getYearMonthProperty().atDay(1).atStartOfDay(), Cell::getLocalDateTimeCellValue),
                     () -> assertBlankCell("Date cell", childNodeRow2.getCell(2)),
                     () -> assertCell("Date time cell", childNodeRow2.getCell(3), CellType.NUMERIC, ValueType.DATE_TIME, childRecord.getDateTimeProperty(), Cell::getDateCellValue)
-                )
+                ),
+                () -> assertExportArea(sheet, 0, 2 + /*template footer*/1, 0, headers.size() - 1)
             );
         }
     }


### PR DESCRIPTION
fixes #103 for 4.x-jakarta